### PR TITLE
[kogito-8176] Update project version to 1.31.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 2.0.0-snapshot
+VERSION ?= 1.31.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/kogito-serverless-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kogito-serverless-operator.clusterserviceversion.yaml
@@ -85,7 +85,7 @@ metadata:
     capabilities: Basic Install
     operators.operatorframework.io/builder: operator-sdk-v1.24.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: kogito-serverless-operator.v2.0.0-snapshot
+  name: kogito-serverless-operator.v1.31.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -274,7 +274,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/kiegroup/kogito-serverless-operator:2.0.0-snapshot
+                image: quay.io/kiegroup/kogito-serverless-operator:1.31.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -355,4 +355,4 @@ spec:
   maturity: alpha
   provider:
     name: kogito-serverlessworkflow-operator
-  version: 2.0.0-snapshot
+  version: 1.31.0

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -22,7 +22,7 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/kiegroup/kogito-serverless-operator
-  newTag: 2.0.0-snapshot
+  newTag: 1.31.0
 # Patching the manager deployment file to add an env var with the operator namespace in
 patchesJson6902:
 - patch: |-


### PR DESCRIPTION
Generated by build jenkins-custom-tradisso-KOGITO-8176-kogito-8176-release-kogito-serverless-operator-deploy-10: https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/custom/job/tradisso/job/KOGITO-8176/job/kogito-8176/job/release/job/kogito-serverless-operator-deploy/10/.
Please do not merge, it shoud be merged automatically.